### PR TITLE
Add panelComponent width

### DIFF
--- a/src/main/java/com/spawnpredictor/overlays/RotationOverlayPanel.java
+++ b/src/main/java/com/spawnpredictor/overlays/RotationOverlayPanel.java
@@ -92,6 +92,10 @@ public class RotationOverlayPanel extends OverlayPanel
 							+ "]")
 					.rightColor(Color.YELLOW)
 					.build());
+
+			panelComponent.setPreferredSize(new Dimension(
+					135,
+					0));
 		}
 		else
 		{


### PR DESCRIPTION
Fix for issue https://github.com/damencs/spawn-predictor/issues/8 forcing the width of the panel so the timer remains on one line.