### PR TITLE
Fix bug in setrotation command

### DIFF
--- a/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
+++ b/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
@@ -426,7 +426,13 @@ public class SpawnPredictorPlugin extends Plugin implements KeyListener
 
 		currentRotation = value;
 		rotationCol = StartLocations.translateRotation(currentRotation, true);
-		updateWaveData(StartLocations.getLookupMap().get(currentRotation));
+		if (currentRotation == 7 && currentWave >= 3)
+		{
+			rsVal = 11; // Different spawn points on the spawn wheel for Wave 4+
+			updateWaveData(rsVal);
+		} else {
+			updateWaveData(StartLocations.getLookupMap().get(currentRotation));
+		}
 		queueChatMessage("You have set the rotation to " + value + ".");
 
 		if (currentWave != -1)

--- a/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
+++ b/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
@@ -430,9 +430,12 @@ public class SpawnPredictorPlugin extends Plugin implements KeyListener
 		{
 			rsVal = 11; // Different spawn points on the spawn wheel for Wave 4+
 			updateWaveData(rsVal);
-		} else {
+		}
+		else
+		{
 			updateWaveData(StartLocations.getLookupMap().get(currentRotation));
 		}
+		
 		queueChatMessage("You have set the rotation to " + value + ".");
 
 		if (currentWave != -1)

--- a/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
+++ b/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
@@ -424,8 +424,8 @@ public class SpawnPredictorPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		rotationCol = value;
-		currentRotation = StartLocations.translateRotation(rotationCol);
+		currentRotation = value;
+		rotationCol = StartLocations.translateRotation(currentRotation, true);
 		updateWaveData(StartLocations.getLookupMap().get(currentRotation));
 		queueChatMessage("You have set the rotation to " + value + ".");
 

--- a/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
+++ b/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java
@@ -713,3 +713,4 @@ public class SpawnPredictorPlugin extends Plugin implements KeyListener
 		chatMessageManager.queue(QueuedMessage.builder().type(ChatMessageType.GAMEMESSAGE).value(message).build());
 	}
 }
+


### PR DESCRIPTION
The user input for the `::setrotation` command is being used incorrectly. The user input is treated as the "rotation column" instead of the rotation. Also it is currently impossible on master branch to set the rotation to [rotation 7](https://oldschool.runescape.wiki/w/TzHaar_Fight_Cave/Rotations/7) after wave 3 has spawned. Tested locally and working. 

This is what happens on the master branch currently when you try to use the `::setrotation` command:
```
set 1 -> actually sets it to rotation 4
set 2 -> actually sets it to rotation 2
set 3 -> actually sets it to rotation 9
set 4 -> actually sets it to rotation 11
set 5 -> actually sets it to rotation 13
set 6 -> actually sets it to rotation 1
set 7 -> actually sets it to rotation 6
set 8 -> actually sets it to rotation 15
set 9 -> actually sets it to rotation 10
set 10-> actually sets it to rotation 8
set 11-> actually sets it to rotation 5
set 12-> actually sets it to rotation 3
set 13-> actually sets it to rotation 12
set 14-> actually sets it to rotation 14
set 15-> actually sets it to rotation 7 (before wave 3) or rotation 8 (on wave 3+)
```
On master there is a rotation 7 wave 3+ hack [here](https://github.com/damencs/spawn-predictor/blob/cff7ba42ef98d82a2c616d76f277f07075c362bd/src/main/java/com/spawnpredictor/SpawnPredictorPlugin.java#L392-L396) that was not getting applied in the `::setrotation` command.

In summary, this PR fixes two bugs:
1. Treat `::setrotation` user input as rotation, not rotation column
2. Apply rotation 7 wave 3+ fix whenever `::setrotation` command runs